### PR TITLE
hasFiles() fix related with empty dirs

### DIFF
--- a/src/Lib/FileStorage.php
+++ b/src/Lib/FileStorage.php
@@ -568,7 +568,7 @@ class FileStorage {
 		$directory = new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS);
 		$iterator = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
 		$iterator->setMaxDepth(0);
-		
+
 		/** @var \SplFileInfo $fileinfo */
 		foreach ($iterator as $fileinfo) {
 			if ($fileinfo->isFile() && strpos($fileinfo->getFilename(), '.') !== 0) {


### PR DESCRIPTION
hasFiles(data dir) shows true in case there's `/var/lib/manticore/.extra/_gpgorigin`. The patch limits max depth to the highest level only, so we don't check inside hidden dirs.