### PR TITLE
feat(storage): support AWS credential provider chain

### DIFF
--- a/src/Lib/S3Storage.php
+++ b/src/Lib/S3Storage.php
@@ -106,25 +106,31 @@ class S3Storage implements StorageInterface {
 		$region = getenv('AWS_REGION') ?: null;
 		$endpoint = getenv('AWS_ENDPOINT_URL') ?: null;
 
-		if (!$accessKey || !$secretKey) {
-			throw new RuntimeException(
-				'S3 credentials required. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.'
-			);
-		}
-
 		$config = [
 			'region' => $region,
 			'version' => 'latest',
-			'credentials' => [
-				'key' => $accessKey,
-				'secret' => $secretKey,
-			],
 			'http' => [
 				'connect_timeout' => (int)(getenv('AWS_S3_CONNECT_TIMEOUT') ?: 10),
 				// Per-part timeout: 64MB at ~50MB/s = ~1.3s, 600s is very generous
 				'timeout' => (int)(getenv('AWS_S3_TIMEOUT') ?: 600),
 			],
 		];
+
+		if ($accessKey && $secretKey) {
+			$credentials = [
+				'key' => $accessKey,
+				'secret' => $secretKey,
+			];
+			$sessionToken = getenv('AWS_SESSION_TOKEN') ?: null;
+			if ($sessionToken) {
+				$credentials['token'] = $sessionToken;
+			}
+			$config['credentials'] = $credentials;
+		}
+		// When no explicit credentials are provided, the SDK uses its default
+		// credential provider chain: env vars, IRSA (web identity token),
+		// shared config/credentials, ECS task role, EC2 instance profile, etc.
+
 		if ($endpoint) {
 			$config['endpoint'] = $endpoint;
 			// Use path-style for custom endpoints (MinIO, Wasabi, etc.)

--- a/test/MockS3Storage.php
+++ b/test/MockS3Storage.php
@@ -28,4 +28,12 @@ class MockS3Storage extends S3Storage {
 			]
 		);
 	}
+
+	/**
+	 * Expose protected method for testing.
+	 * @return array<string,mixed>
+	 */
+	public function exposeBuildS3ClientConfig(): array {
+		return $this->buildS3ClientConfig();
+	}
 }

--- a/test/S3StorageTest.php
+++ b/test/S3StorageTest.php
@@ -257,4 +257,60 @@ class S3StorageTest extends TestCase {
 		MockS3Storage::createDir('backups/backup-20260312050529/data');
 		$this->assertTrue(true); // no exception = pass
 	}
+
+	// -------------------------------------------------------------------------
+	// buildS3ClientConfig() — credential chain
+	// -------------------------------------------------------------------------
+
+	public function testBuildConfigWithExplicitCredentials(): void {
+		putenv('AWS_ACCESS_KEY_ID=my-key');
+		putenv('AWS_SECRET_ACCESS_KEY=my-secret');
+		putenv('AWS_SESSION_TOKEN');
+		putenv('AWS_S3_ENCRYPTION=0');
+		putenv('AWS_REGION=us-east-1');
+
+		$storage = new MockS3Storage('s3://my-bucket');
+		$config = $storage->exposeBuildS3ClientConfig();
+
+		$this->assertArrayHasKey('credentials', $config);
+		$credentials = (array)$config['credentials'];
+		$this->assertSame('my-key', $credentials['key']);
+		$this->assertSame('my-secret', $credentials['secret']);
+		$this->assertArrayNotHasKey('token', $credentials);
+	}
+
+	public function testBuildConfigWithSessionToken(): void {
+		putenv('AWS_ACCESS_KEY_ID=my-key');
+		putenv('AWS_SECRET_ACCESS_KEY=my-secret');
+		putenv('AWS_SESSION_TOKEN=my-token');
+		putenv('AWS_S3_ENCRYPTION=0');
+		putenv('AWS_REGION=us-east-1');
+
+		$storage = new MockS3Storage('s3://my-bucket');
+		$config = $storage->exposeBuildS3ClientConfig();
+
+		$credentials = (array)$config['credentials'];
+		$this->assertSame('my-token', $credentials['token']);
+
+		putenv('AWS_SESSION_TOKEN');
+	}
+
+	public function testBuildConfigWithoutCredentialsFallsBackToChain(): void {
+		putenv('AWS_ACCESS_KEY_ID');
+		putenv('AWS_SECRET_ACCESS_KEY');
+		putenv('AWS_S3_ENCRYPTION=0');
+		putenv('AWS_REGION=us-east-1');
+
+		$storage = new MockS3Storage('s3://my-bucket');
+		$config = $storage->exposeBuildS3ClientConfig();
+
+		// No 'credentials' key → SDK uses default credential provider chain
+		$this->assertArrayNotHasKey('credentials', $config);
+		$this->assertSame('us-east-1', $config['region']);
+		$this->assertSame('latest', $config['version']);
+
+		// Restore for other tests
+		putenv('AWS_ACCESS_KEY_ID=test-key');
+		putenv('AWS_SECRET_ACCESS_KEY=test-secret');
+	}
 }


### PR DESCRIPTION
- Make AWS credentials optional, use SDK default chain when not provided
- Add support for AWS_SESSION_TOKEN (temporary credentials)
- Remove hard requirement that throws exception when env vars missing
- Add tests for explicit credentials, session tokens, and chain fallback