### PR TITLE
fix: release nested freezes after backup failure

### DIFF
--- a/src/Lib/ManticoreBackup.php
+++ b/src/Lib/ManticoreBackup.php
@@ -191,25 +191,33 @@ class ManticoreBackup {
 			}
 
 			$files = $client->freeze($index);
-			$tableSize = $storage::calculateFilesSize($files);
-			$totalTableSize += $tableSize;
-			++$totalTableCount;
-			metric('backup_table_size', $tableSize);
-			println(
-				LogLevel::Info,
-				'  ' . $index . ' ('  . $type . ') [' . format_bytes($tableSize) . ']...'
-			);
+			try {
+				$tableSize = $storage::calculateFilesSize($files);
+				$totalTableSize += $tableSize;
+				++$totalTableCount;
+				metric('backup_table_size', $tableSize);
+				println(
+					LogLevel::Info,
+					'  ' . $index . ' ('  . $type . ') [' . format_bytes($tableSize) . ']...'
+				);
 
-			$backupPath = $destination['data'] . DIRECTORY_SEPARATOR . $index;
-			$storage->createDir(
-				$backupPath,
-				$config->dataDir . DIRECTORY_SEPARATOR . $index
-			);
+				$backupPath = $destination['data'] . DIRECTORY_SEPARATOR . $index;
+				$storage->createDir(
+					$backupPath,
+					$config->dataDir . DIRECTORY_SEPARATOR . $index
+				);
 
-			$isOk = $storage->copyPaths($files, $backupPath);
-			println(LogLevel::Info, '   ' . get_op_result($isOk));
-			$result = $result && $isOk;
-			$client->unfreeze($index);
+				$isOk = $storage->copyPaths($files, $backupPath);
+				println(LogLevel::Info, '   ' . get_op_result($isOk));
+				$result = $result && $isOk;
+			} catch (\Throwable $e) {
+				// The shutdown closure reads this flag by reference
+				// phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable
+				$isUnfrozen = $client->unfreezeAll();
+				throw $e;
+			} finally {
+				$client->unfreeze($index);
+			}
 		}
 
 		if (!$client->unfreezeAll()) {

--- a/test/ManticoreBackupTest.php
+++ b/test/ManticoreBackupTest.php
@@ -93,6 +93,25 @@ class ManticoreBackupTest extends SearchdTestCase {
 		$this->assertNotContains('people', $lockedTables);
 	}
 
+	public function testStoreUnfreezesTablesWhenFrozenFileIsMissing(): void {
+		[$config, $storage] = $this->initTestEnv();
+		$client = new ManticoreMissingFrozenFileClient([$config]);
+
+		$exception = null;
+		try {
+			ManticoreBackup::run('store', [$client, $storage, ['people']]);
+		} catch (Throwable $e) {
+			$exception = $e;
+		}
+
+		$this->assertTrue($client->missingFileInjected);
+		$this->assertInstanceOf(Throwable::class, $exception);
+		$this->assertStringContainsString('filesize(): stat failed', $exception->getMessage());
+		$result = $client->execute('SHOW LOCKS');
+		$lockedTables = array_column($result[0]['data'], 'Name');
+		$this->assertNotContains('people', $lockedTables);
+	}
+
 	public function testShutdownUnfreezeAttemptsUnfreezeWhenEndpointIsUnavailable(): void {
 		$client = new ManticoreUnfreezeFailedClient();
 		$reflection = new ReflectionClass(ManticoreBackup::class);
@@ -431,5 +450,20 @@ class ManticoreUnfreezeFailedClient extends ManticoreClient {
 	public function unfreezeAll(): bool {
 		$this->unfreezeAllCalled = true;
 		throw new SearchdException('failed to execute query: "SHOW TABLES"');
+	}
+}
+
+// @codingStandardsIgnoreStart
+class ManticoreMissingFrozenFileClient extends ManticoreClient {
+  // @codingStandardsIgnoreEnd
+	public bool $missingFileInjected = false;
+
+	public function freeze(array|string $tables): array {
+		$files = parent::freeze($tables);
+		if (is_string($tables)) {
+			$this->missingFileInjected = true;
+			return [$this->getConfig()->dataDir . DIRECTORY_SEPARATOR . $tables . DIRECTORY_SEPARATOR . 'missing'];
+		}
+		return $files;
 	}
 }


### PR DESCRIPTION
This PR prevents a failed backup from leaving an RT table frozen when an error occurs after its per-table `FREEZE`.

Follow-up to #138.

## How to reproduce manually

```
rm -fr /opt/homebrew/var/manticore/t
mysql -h0 -P9306 -e "drop table if exists t; CREATE TABLE t(f text) exceptions_list='a=>b'; INSERT INTO t(id,f) VALUES (1,'a'); FLUSH RAMCHUNK t"
rm /opt/homebrew/var/manticore/t/exceptions_chunk0_0.txt
manticore-backup --backup-dir=/tmp/

 ✘  ~/manticoresearch-buddy  main  mysql -P9306 -h0 -e "show locks"
+------+------+-----------+-----------------+
| Type | Name | Lock Type | Additional Info |
+------+------+-----------+-----------------+
| rt   | t    | freeze    | Count: 1        |
+------+------+-----------+-----------------+
```

## Root cause

Backup freezes tables twice:

1. A bulk `FREEZE` protects all selected tables.
2. Each table is frozen again while its files are copied.

If a frozen file disappears before it is processed, such as an exceptions file, `filesize()` throws before the per-table `UNFREEZE` is reached.

The existing shutdown cleanup releases only one freeze level, leaving the affected table locked with `Count: 1`.

## Fix

Wrap the work following the per-table `FREEZE` in `try/catch/finally`:

- On failure, release the initial bulk freeze and rethrow the original exception.
- Always release the per-table freeze in `finally`.

This balances both freeze levels without querying `SHOW LOCKS` in production.

## Test

Added a regression test that:

- Performs the real bulk and per-table freezes.
- Injects a missing file after the per-table freeze.
- Verifies that backup fails with the expected `filesize(): stat failed` error.
- Verifies in the same process that `SHOW LOCKS` contains no lock for the table.
